### PR TITLE
Update links in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,6 @@ community at the following times:
 * Friday December 11th 2020, between XX and YY
 
 [aug-blog]: https://blog.rust-lang.org/2020/08/18/laying-the-foundation-for-rusts-future.html
-[issues]: https://github.com/rust-lang/foundation-ama-2020/issues
-[new]: https://github.com/rust-lang/foundation-ama-2020/issues/new?template=question.md
-[faq]: https://github.com/rust-lang/foundation-ama-2020/blob/main/FAQ.md
+[issues]: https://github.com/rust-lang/foundation-faq-2020/issues
+[new]: https://github.com/rust-lang/foundation-faq-2020/issues/new?template=question.md
+[faq]: https://github.com/rust-lang/foundation-faq-2020/blob/main/FAQ.md


### PR DESCRIPTION
Some links in the REAMDE were referincing the old repository name.